### PR TITLE
Name for MegaCD corrected

### DIFF
--- a/arduino/MiSTer_tty2epaper/MiSTer_tty2epaper.ino
+++ b/arduino/MiSTer_tty2epaper/MiSTer_tty2epaper.ino
@@ -119,7 +119,7 @@ void loop()
              } else if (command == "Jaguar"){
                  prevMiSTerLogo = false;
                  drawLogo(Jaguar_LOGO);
-             } else if (command == "MEGACD"){
+             } else if (command == "MegaCD"){
                  prevMiSTerLogo = false;
                  drawLogo(MEGACD_LOGO);
              } else if (command == "Minimig"){


### PR DESCRIPTION
Got my tty2epaper working, works great.

I changed the Name for MegaCD  from **MEGACD** to **MegaCD** to get it shown.
Now I need to see where I can get a pcb.